### PR TITLE
make appdata file available

### DIFF
--- a/com.arduino.App.json
+++ b/com.arduino.App.json
@@ -36,6 +36,11 @@
                   "type": "file",
                   "path": "com.arduino.App.desktop",
                   "dest-filename": "com.arduino.App.desktop"
+              },
+              {
+                  "type": "file",
+                  "path": "com.arduino.App.appdata.xml",
+                  "dest-filename": "com.arduino.App.appdata.xml"
               }
           ]
       }


### PR DESCRIPTION
Appdata xml file was not available to be installed by flatpak.